### PR TITLE
feat: fetch branch list with max limit

### DIFF
--- a/src/actions/findBranchByName.js
+++ b/src/actions/findBranchByName.js
@@ -3,11 +3,14 @@ import lokaliseApi from "../lokaliseApi";
 import formatBranchName from "../utils/formatBranchName";
 const projectId = core.getInput("projectId");
 
+const BRANCH_LISTING_MAX_LIMIT = 5000;
+
 const findBranchByName = async (branchName) => {
   try {
     const formattedBranchName = formatBranchName(branchName);
     const branchList = await lokaliseApi.branches.list({
       project_id: projectId,
+      limit: BRANCH_LISTING_MAX_LIMIT,
     });
     const foundBranch = branchList.find(
       (element) => element.name === formattedBranchName


### PR DESCRIPTION
把拉 branch 列表的 request limit 參數調成 lokalise 的上限 5000
see https://lokalise.github.io/node-lokalise-api/api/branches & https://app.lokalise.com/api2docs/curl/#transition-list-all-branches-get